### PR TITLE
Fix deprecation warnings from Faker

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
-    "@types/faker": "^5.1.5",
+    "@types/faker": "^5.5.8",
     "@types/jest": "^26.0.18",
     "@typescript-eslint/eslint-plugin": "^4.9.1",
     "@typescript-eslint/parser": "^4.9.1",
@@ -44,7 +44,7 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "faker": "^5.1.0",
+    "faker": "^5.5.3",
     "ts-node": "^9.1.1"
   }
 }

--- a/src/generateNhsNumber.ts
+++ b/src/generateNhsNumber.ts
@@ -3,7 +3,7 @@ import faker from "faker"
 export function generateValidNhsNumbers(num: number) {
     const numbers: string[] = [];
     while (numbers.length < num) {
-        const number = faker.random.number({ min: 100000000, max: 999999999 }).toString()
+        const number = faker.datatype.number({ min: 100000000, max: 999999999 }).toString()
         const multipliedTotal = number.split('').reduce((acc, curr, i) => acc + (Number(curr) * (10 - i)), 0)
         const remainder = multipliedTotal % 11
         let checkDigit = 11 - remainder
@@ -27,7 +27,7 @@ export function generateInvalidNhsNumbers(num: number) {
         
         let checkDigit: number
 
-        const number = faker.random.number({ min: 100000000, max: 999999999 }).toString()
+        const number = faker.datatype.number({ min: 100000000, max: 999999999 }).toString()
         const multipliedTotal = number.split('').reduce((acc, curr, i) => acc + (Number(curr) * (10 - i)), 0)
         const remainder = multipliedTotal % 11
         checkDigit = 11 - remainder

--- a/src/generateNhsNumbers.test.ts
+++ b/src/generateNhsNumbers.test.ts
@@ -4,7 +4,7 @@ import faker from "faker"
 
 describe("generateInvalidNumbers", () => {
     it("should generate X invalid nhs numbers", () => {
-        const expectedNumberOfResults = faker.random.number({ min: 5, max: 10 })
+        const expectedNumberOfResults = faker.datatype.number({ min: 5, max: 10 })
         const result = generateInvalidNhsNumbers(expectedNumberOfResults)
         
         expect(result.length).toBe(expectedNumberOfResults)
@@ -14,7 +14,7 @@ describe("generateInvalidNumbers", () => {
 
 describe("generateValidNumbers", () => {
     it("should generate X valid nhs numbers", () => {
-        const expectedNumberOfResults = faker.random.number({ min: 5, max: 10 })
+        const expectedNumberOfResults = faker.datatype.number({ min: 5, max: 10 })
         const result = generateValidNhsNumbers(expectedNumberOfResults)
 
         expect(result.length).toBe(expectedNumberOfResults)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,10 +1137,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/faker@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.1.5.tgz#f14b015e0100232bb00c6dd7611505efb08709a0"
-  integrity sha512-2uEQFb7bsx68rqD4F8q95wZq6LTLOyexjv6BnvJogCO4jStkyc6IDEkODPQcWfovI6g6M3uPQ2/uD/oedJKkNw==
+"@types/faker@^5.5.8":
+  version "5.5.8"
+  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.8.tgz#6649adfdfdbb0acf95361fc48f2d0ca6e88bd1cf"
+  integrity sha512-bsl0rYsaZVHlZkynL5O04q6YXDmVjcid6MbOHWqvtE2WWs/EKhp0qchDDhVWlWyQXUffX1G83X9LnMxRl8S/Mw==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
@@ -2379,10 +2379,10 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-faker@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.1.0.tgz#e10fa1dec4502551aee0eb771617a7e7b94692e8"
-  integrity sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw==
+faker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"


### PR DESCRIPTION
Fixes deprecation warnings from Faker:
- upgrade Faker to latest version
- swap instances of `faker.random.number` with `faker.datatype.number`

Fixes #37